### PR TITLE
feat: support for mounted system partition at /mnt/system

### DIFF
--- a/zip-content/scripts/install.sh
+++ b/zip-content/scripts/install.sh
@@ -76,6 +76,8 @@ if test -f "${ANDROID_ROOT:-/system_root/system}/build.prop"; then
   SYS_PATH="${ANDROID_ROOT:-/system_root/system}"
 elif test -f '/system_root/system/build.prop'; then
   SYS_PATH='/system_root/system'
+elif test -f '/mnt/system/system/build.prop'; then
+  SYS_PATH='/mnt/system/system'
 elif test -f '/system/system/build.prop'; then
   SYS_PATH='/system/system'
 elif test -f '/system/build.prop'; then
@@ -87,6 +89,8 @@ else
     SYS_PATH="${ANDROID_ROOT:-}"
   elif test -e '/system_root' && mount_partition '/system_root' && test -f '/system_root/system/build.prop'; then
     SYS_PATH='/system_root/system'
+  elif test -e '/mnt/system' && mount_partition '/mnt/system' && test -f '/mnt/system/system/build.prop'; then
+    SYS_PATH='/mnt/system/system'
   elif test -e '/system' && mount_partition '/system' && test -f '/system/system/build.prop'; then
     SYS_PATH='/system/system'
   elif test -f '/system/build.prop'; then
@@ -481,6 +485,7 @@ fi
 
 if test "${SYS_INIT_STATUS:?}" = '1'; then
   if test -e '/system_root'; then unmount '/system_root'; fi
+  if test -e '/mnt/system'; then unmount '/mnt/system'; fi
   if test -e '/system'; then unmount '/system'; fi
 fi
 


### PR DESCRIPTION
This will enable support for flashing when the system partition is mounted on `/mnt/system` which is the case on my Oneplus 8 Pro with LOS 20.